### PR TITLE
feat: Recipe for base infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+auth.json
+.terraform*

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.51.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "mha-terraform-remote-state"
+    prefix = "terraform/state"
+  }
+}
+
+provider "google" {
+  credentials = file(var.credentials_file)
+
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_compute_network" "vpc_network" {
+  name = "mha-network"
+}
+
+resource "google_compute_firewall" "mha_firewall" {
+  name    = "mha-firewall"
+  network = google_compute_network.vpc_network.name
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_tags = ["web"]
+}
+
+resource "google_compute_instance" "mha_server" {
+  name         = "mha-server"
+  machine_type = "e2-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "cos-cloud/cos-stable"
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.vpc_network.name
+    access_config {
+      # empty block configures public IP to be assigned
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_compute_instance" "mha_server" {
 
   boot_disk {
     initialize_params {
-      image = "cos-cloud/cos-stable"
+      image = "debian-cloud/debian-11"
     }
   }
 
@@ -56,4 +56,6 @@ resource "google_compute_instance" "mha_server" {
       # empty block configures public IP to be assigned
     }
   }
+
+  metadata_startup_script = file(var.startup_script_file)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "ip" {
-  value = google_compute_instance.mha_server.network_interface.0.network_ip
+  value = google_compute_instance.mha_server.network_interface[0].access_config[0].nat_ip
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "ip" {
+  value = google_compute_instance.mha_server.network_interface.0.network_ip
+}

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+apt update

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,2 +1,48 @@
-#! /bin/bash
-apt update
+#!/bin/bash
+
+# Update the package repository and upgrade installed packages
+sudo apt-get update
+
+# Decode the Base64 authfile and store the result in a variable
+decoded_string=$(echo "${auth_file}" | base64 --decode)
+
+# Write auth details to file
+echo $decoded_string | tee /tmp/authfile.json
+
+# Set the project ID
+PROJECT_ID="my-health-app-402819"
+
+
+# Authenticate gcloud using the service account key file
+gcloud auth activate-service-account ${service_account_name} --key-file="/tmp/authfile.json" --project="$PROJECT_ID"
+
+# Fetch the secret payload using gcloud
+SSH_KEY=$(gcloud secrets versions access latest --secret="admin-ssh-key-public" --project="$PROJECT_ID")
+ADMIN_USER=$(gcloud secrets versions access latest --secret="admin-user-name" --project="$PROJECT_ID")
+ADMIN_PASSWORD=$(gcloud secrets versions access latest --secret="admin-user-password" --project="$PROJECT_ID")
+
+if id "$ADMIN_USER" &>/dev/null; then
+    echo "User '$ADMIN_USER' exists."
+else
+    # Create a non-root user and add it to the sudo group
+    sudo /sbin/useradd -m -s /bin/bash $ADMIN_USER
+    sudo /sbin/usermod -aG sudo $ADMIN_USER
+    # TODO: refactor to pull from google secrets
+    echo "$ADMIN_USER:$ADMIN_PASSWORD" | sudo /sbin/chpasswd
+fi
+
+# Publish SSH key
+if [ -d "/home/$ADMIN_USER/.ssh" ]; then
+    # do nothing
+    :
+else
+    mkdir /home/$ADMIN_USER/.ssh
+    # TODO: refactor to pull from google secrets
+    echo $SSH_KEY >> /home/$ADMIN_USER/.ssh/authorized_keys 
+fi
+
+# Clean up authfile
+rm -f /tmp/authfile.json
+
+# Optional: Install additional packages or perform other custom configurations
+# sudo apt-get install -y <package-name>

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,3 +1,4 @@
-project             = "my-health-app-402819"
-credentials_file    = "auth.json"
-startup_script_file = "scripts/startup.sh"
+project              = "my-health-app-402819"
+credentials_file     = "auth.json"
+startup_script_file  = "scripts/startup.sh"
+service_account_name = "github-terraform@my-health-app-402819.iam.gserviceaccount.com"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,2 +1,3 @@
-project          = "my-health-app-402819"
-credentials_file = "auth.json"
+project             = "my-health-app-402819"
+credentials_file    = "auth.json"
+startup_script_file = "scripts/startup.sh"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,2 @@
+project          = "my-health-app-402819"
+credentials_file = "auth.json"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,11 @@
+variable "project" {}
+
+variable "credentials_file" {}
+
+variable "region" {
+  default = "us-west1"
+}
+
+variable "zone" {
+  default = "us-west1-c"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,8 @@ variable "project" {}
 
 variable "credentials_file" {}
 
+variable "startup_script_file" {}
+
 variable "region" {
   default = "us-west1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,8 @@ variable "credentials_file" {}
 
 variable "startup_script_file" {}
 
+variable "service_account_name" {}
+
 variable "region" {
   default = "us-west1"
 }


### PR DESCRIPTION
Defines the initial set of resources we will be using for the health app, including:

- a VPC network 
- a virtual instance to host the elixir backend and postgres in containers
    - a public IP for the instance
- a firewall allowing ports 80 and 443 to the instance

This currently relies on using a JSON auth file that will not be committed to the repo for security reasons.
It loads the details for an admin user from Google Secret Manager.